### PR TITLE
Add Pushbullet support, use a JSON for email IDs, minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 config.ini
 logs/
 *.pickle
+*.json

--- a/config-template.ini
+++ b/config-template.ini
@@ -9,3 +9,11 @@ password = mailserverpassword
 
 # Info for sending the email
 from = "My Name (automated)" <myaddress@domain.com>
+
+
+[pushbullet]
+# Create an access token here: https://www.pushbullet.com/#settings/account
+# Set to false to disable
+pushbullet_access_token = myaccesstoken
+# The device name to push to, set to false to use all devices
+pushbullet_device = My Phone

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -384,8 +384,8 @@ def main():
                 if status[0] == "OK":
                     LOGGER.info("Successfully saved the email with the tickets.")
                     completed.append({"id": message["Message-ID"],
-                                   "date": message["Date"],
-                                   "subject": message["Subject"]})
+                                      "date": message["Date"],
+                                      "subject": message["Subject"]})
                     LOGGER.debug("Saving the message ID %s to the completed messages.",
                                  message["Message-ID"])
                 else:

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -368,9 +368,10 @@ def main():
 
             # Check if the email has already been processed
             if check_if_already_processed(server, message, completed):
-                completed.append({"id": message["Message-ID"],
-                                  "date": message["Date"],
-                                  "subject": message["Subject"]})
+                if message["Message-ID"] not in [c["id"] for c in completed]:
+                    completed.append({"id": message["Message-ID"],
+                                      "date": message["Date"],
+                                      "subject": message["Subject"]})
                 continue
 
             # Download the tickets into an email

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -38,7 +38,7 @@ TIMEZONE = timezone("Europe/London")
 COMPLETED_MESSAGES_FILE = "completed_messages.json"
 
 # The date format to use for email dates
-EMAIL_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %z (UTC)"
+EMAIL_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %z"
 
 # The string to use for the email ID
 EMAIl_ID_STRING = "cmenon12-download-trainline-tickets"
@@ -356,7 +356,7 @@ def main():
             LOGGER.info("Fetched email %s.", message["Subject"])
 
             # Check if the email is too old
-            if datetime.strptime(message["Date"], EMAIL_DATE_FORMAT) < since:
+            if datetime.strptime(message["Date"][:31], EMAIL_DATE_FORMAT) < since:
                 LOGGER.info("Email is too old, skipping.")
                 continue
 

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -258,7 +258,7 @@ def prepare_ticket_email(message: Message,
     ticket_email["Subject"] = f"Re: {message['Subject']}"
     ticket_email["To"] = message["To"]
     ticket_email["From"] = email_config["from"]
-    date = (datetime.strptime(message["Date"], EMAIL_DATE_FORMAT) + timedelta(minutes=10)).strftime(
+    date = (datetime.strptime(message["Date"][:31], EMAIL_DATE_FORMAT) + timedelta(minutes=10)).strftime(
         EMAIL_DATE_FORMAT)
     LOGGER.debug("Setting the date to %s.", date)
     ticket_email["Date"] = date
@@ -378,7 +378,7 @@ def main():
             if ticket_email:
                 send_via_pushbullet(ticket_email, pb_config)
                 status = server.append("inbox", "\\Seen",
-                                       datetime.strptime(message["Date"],
+                                       datetime.strptime(message["Date"][:31],
                                                          EMAIL_DATE_FORMAT) + timedelta(
                                            minutes=10), ticket_email.as_bytes())
                 if status[0] == "OK":

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -161,6 +161,12 @@ def fetch_tickets(urls: list[str]) -> list[MIMEBase]:
         url = f"https://download.thetrainline.com/resource/{req_id}"
         LOGGER.debug("Downloading ticket PDF from %s.", url)
         response = session.get(url, timeout=10)
+
+        # Stop if the ticket doesn't exist in Trainline's system
+        if response.url == "https://www.thetrainline.com/error":
+            LOGGER.warning("Ticket no longer exists, skipping.")
+            continue
+
         response.raise_for_status()
 
         # Stop if this is not a PDF file

--- a/download_tickets.py
+++ b/download_tickets.py
@@ -275,11 +275,11 @@ def prepare_ticket_email(message: Message,
     return ticket_email
 
 
-def send_via_pushbullet(message: MIMEMultipart, pb_config: configparser.SectionProxy) -> None:
+def send_via_pushbullet(ticket_email: MIMEMultipart, pb_config: configparser.SectionProxy) -> None:
     """Send the tickets via Pushbullet.
 
-    :param message: the email message with the tickets
-    :type message: email.mime.multipart.MIMEMultipart
+    :param ticket_email: the email message with the tickets
+    :type ticket_email: email.mime.multipart.MIMEMultipart
     :param pb_config: the Pushbullet config
     :type pb_config: configparser.SectionProxy
     """
@@ -293,7 +293,7 @@ def send_via_pushbullet(message: MIMEMultipart, pb_config: configparser.SectionP
     pb = Pushbullet(pb_config["pushbullet_access_token"])
 
     # Iterate over each part of the message
-    for part in message.walk():
+    for part in ticket_email.walk():
         if part.get_content_type() == "application/pdf":
 
             # Prepare the file to send
@@ -302,7 +302,7 @@ def send_via_pushbullet(message: MIMEMultipart, pb_config: configparser.SectionP
 
             # Upload and send the file
             LOGGER.info("Sending the ticket %s via Pushbullet.", filename)
-            file_data = pb.upload_file(file_bytes, filename)
+            file_data = pb.upload_file(file_bytes, filename, file_type="application/pdf")
             if pb_config.get("pushbullet_device", "false").lower() == "false":
                 pb.push_file(**file_data, device=pb_config.get("pushbullet_device"))
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.12.3
+pushbullet.py==0.12.0
 pytz==2024.1
 requests==2.32.2
 timelength==2.0.2


### PR DESCRIPTION
- Add Pushbullet support.
- Use a JSON file for saving the email IDs (and subject and date) instead of the pickle file. This allows for easier debugging.
- Apply a couple of small fixes.